### PR TITLE
add option to provide base64 encoded credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,11 @@ const convertFn = () => {
 }
 
 const publishContent = (content: string | undefined) => {
-  const basicauth = Buffer.from(
-    `${core.getInput('cnfluser')}:${core.getInput('apikey')}`
-  ).toString('base64')
+  const basicauth = core.getInput('basicauth')
+    ? core.getInput('basicauth')
+    : Buffer.from(
+        `${core.getInput('cnfluser')}:${core.getInput('apikey')}`
+      ).toString('base64')
   const payload = {
     type: 'page',
     title: core.getInput('title'),


### PR DESCRIPTION
- provide base64 encoded credentials instead of username and password/api token